### PR TITLE
update groupId to org.eclipse.pass

### DIFF
--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -52,13 +52,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-data-harvest</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-etl-model</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -19,13 +19,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-etl-util</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-etl-model</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -52,7 +52,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-data-transform-load</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -12,30 +12,30 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>entrez-pmid-lookup</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-etl-util</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-etl-model</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-model</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-status-service</artifactId>
     </dependency>
 
@@ -45,7 +45,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-pass-client</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -66,7 +66,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-3.2-5</name>
+              <name>oapass/fcrepo:4.7.5-3.5</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -77,12 +77,12 @@
                   <FCREPO_STOMP_PORT>${FCREPO_STOMP_PORT}</FCREPO_STOMP_PORT>
                   <FCREPO_JMS_BASEURL>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</FCREPO_JMS_BASEURL>
                   <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
-                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld
+                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.5.jsonld
                   </COMPACTION_URI>
                   <COMPACTION_PRELOAD_URI_PASS_STATIC>
-                    https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld
+                    https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.5.jsonld
                   </COMPACTION_PRELOAD_URI_PASS_STATIC>
-                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-3.1.jsonld
+                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-3.5.jsonld
                   </COMPACTION_PRELOAD_FILE_PASS_STATIC>
                 </env>
                 <ports>
@@ -133,7 +133,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer@sha256:e51092a9d433219d52207f1ec3f5ea7c652d51f516bcbe9434dae556b921546d</name>
+              <name>oapass/indexer:0.0.18-3.4-1</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>
@@ -213,7 +213,7 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-data-transform-load-cli</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -14,7 +14,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-model</artifactId>
     </dependency>
 

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
     <version>1.4.2-SNAPSHOT</version>
   </parent>
@@ -13,17 +13,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-client-api</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-data-client</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>nihms-etl-util</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
   <version>1.4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -55,7 +54,7 @@
   <properties>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.30.0</docker-maven-plugin.version>
-    <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
@@ -68,14 +67,14 @@
     <org-json.version>20180130</org-json.version>
     <commons-csv.version>1.5</commons-csv.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <pass-client.version>0.8.0</pass-client.version>
+    <pass-client.version>0.9.0-SNAPSHOT</pass-client.version>
     <logback.version>1.2.3</logback.version>
     <selenium.version>3.11.0</selenium.version>
     <args4j.version>2.33</args4j.version>
     <mockito.version>1.9.5</mockito.version>
     <handy-uri-templates.version>2.1.8</handy-uri-templates.version>
     <commons-io.version>2.6</commons-io.version>
-    <okhttp.version>3.14.1</okhttp.version>
+    <okhttp.version>4.10.0</okhttp.version>
   </properties>
 
   <modules>
@@ -183,31 +182,31 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.dataconservancy.pass</groupId>
+        <groupId>org.eclipse.pass</groupId>
         <artifactId>pass-client-api</artifactId>
         <version>${pass-client.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.dataconservancy.pass</groupId>
+        <groupId>org.eclipse.pass</groupId>
         <artifactId>pass-model</artifactId>
         <version>${pass-client.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.dataconservancy.pass</groupId>
+        <groupId>org.eclipse.pass</groupId>
         <artifactId>pass-model-nihms</artifactId>
         <version>${pass-client.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.dataconservancy.pass</groupId>
+        <groupId>org.eclipse.pass</groupId>
         <artifactId>pass-status-service</artifactId>
         <version>${pass-client.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.dataconservancy.pass</groupId>
+        <groupId>org.eclipse.pass</groupId>
         <artifactId>pass-data-client</artifactId>
         <version>${pass-client.version}</version>
       </dependency>


### PR DESCRIPTION
updated group ids and a couple dependency versions. ITs could not be brought all the way up to model 3.5, as it appears we don't have an indexer image with that version of the model. we are using 3.5  for compaction, and a 3.5 version of fedora, but are using an indexer compatible with and configured for 3.4.

